### PR TITLE
use a more specific port for docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     container_name: algopy_app
@@ -6,7 +5,7 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "5000:5000"
+      - "8501:8501"
     volumes:
       - .:/app  # Mount the current directory to /app in the container
       - ./database/db:/app/database/db  # Mount the volume for finstore database


### PR DESCRIPTION
- As mentioned in #13 , 5000 port is used for Airplay Receiver in Mac causing frequent trouble. 
- Additionally not everyone uses VS code to enable auto-port forwarding for all internally opened ports for streamlit. 
- Setting the default port to 8501 which is also the default port for streamlit