### PR TITLE
Fix dead SourceForge URL for TA-Lib source in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && \
  apt-get clean && \
  rm -rf /var/lib/apt/lists/*
 
-RUN wget https://netcologne.dl.sourceforge.net/project/ta-lib/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz && \
+RUN wget -O ta-lib-0.4.0-src.tar.gz "https://sourceforge.net/projects/ta-lib/files/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz/download" && \
   tar -xvzf ta-lib-0.4.0-src.tar.gz && \
   cd ta-lib/ && \
   ./configure --prefix=/usr --build=unknown-unknown-linux && \


### PR DESCRIPTION
Fixes #24

## Problem

`Dockerfile` line 10 downloads the TA-Lib source from a specific SourceForge mirror subdomain:

```dockerfile
RUN wget https://netcologne.dl.sourceforge.net/project/ta-lib/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz && \
```

`netcologne.dl.sourceforge.net` no longer resolves in DNS (`Name or service not known`), so this step fails immediately and `docker compose up -d --build` — the exact command in the README's setup instructions — is broken for every fresh clone.

## Fix

Switch to SourceForge's canonical download redirect URL, which transparently redirects to a live mirror:

```diff
-RUN wget https://netcologne.dl.sourceforge.net/project/ta-lib/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz && \
+RUN wget -O ta-lib-0.4.0-src.tar.gz "https://sourceforge.net/projects/ta-lib/files/ta-lib/0.4.0/ta-lib-0.4.0-src.tar.gz/download" && \
```

`-O ta-lib-0.4.0-src.tar.gz` is required because the canonical URL ends in `/download` rather than a filename — without it, `wget` would save the file as `download` and the subsequent `tar -xvzf ta-lib-0.4.0-src.tar.gz` would fail with "no such file".

## Verification

Tested the replacement URL from inside a container: it redirects correctly and downloads a valid gzip tarball (1,330,299 bytes), which extracts cleanly to `ta-lib-0.4.0-src.tar` / `ta-lib/`, allowing the rest of the `RUN` step (`./configure && make && make install`) to proceed as before.

## Scope

One-line change, no other behavior affected.
