### PR TITLE
Add StrategyValidator: schema checks + look-ahead bias detection (#9)

### DIFF
--- a/docs/strategy_development.md
+++ b/docs/strategy_development.md
@@ -57,6 +57,31 @@ class MyCustomStrategy(StrategyBaseClass):
 
 - **Backtesting:** Run your strategy against historical data.
 - **Live Monitoring:** Check real-time performance via the **Strategy Monitor** dashboard.
+- **Verification:** Before trusting a new strategy, run it through `StrategyValidator`
+  (see below) to catch schema bugs and look-ahead bias automatically.
+
+### Automated Strategy Verification
+
+`strategy/strategy_validator.py` provides `StrategyValidator`, which checks:
+
+1. **Output schema** — `entries`/`exits`/`close_data`/`open_data` share the same index
+   and columns, `entries`/`exits` are boolean with no NaNs, and no bar has both an
+   entry and an exit signal for the same symbol at once.
+2. **Look-ahead bias** — your strategy is run once on the full history, then again on
+   truncated prefixes of it. If a signal at time T changes depending on whether data
+   *after* T is present in the input, that's proof the strategy is reading future data
+   it shouldn't have access to yet.
+
+```python
+from strategy.strategy_validator import StrategyValidator
+from strategy.public.EmaStrat import EMAStrategy
+
+strategy = EMAStrategy(fast_ema_period=10, slow_ema_period=100)
+report = StrategyValidator().validate(strategy, ohlcv_data)
+
+print(report)  # ValidationReport: PASSED, or a list of specific issues found
+assert report.passed
+```
 
 ### Considerations
 

--- a/strategy/strategy_validator.py
+++ b/strategy/strategy_validator.py
@@ -1,0 +1,198 @@
+"""
+Strategy verification utilities.
+
+Provides `StrategyValidator`, which checks a StrategyBaseClass implementation
+for two classes of problems before it is trusted for backtesting/live trading:
+
+1. Output schema validity — entries/exits/close_data/open_data must be
+   boolean-aligned DataFrames sharing the same index and columns, with no
+   NaNs and no bar where entries and exits are both True for the same symbol.
+
+2. Look-ahead bias (future data leaking into past signals) — the strategy is
+   run once on the full OHLCV history, then re-run on progressively truncated
+   prefixes of that same history. A correct strategy's signal at time T can
+   only depend on data up to and including T, so the truncated run's signals
+   must exactly match the full run's signals over the overlapping period. Any
+   mismatch means the strategy peeked at data that would not yet have existed
+   at that point in time.
+
+See discussion: https://github.com/himanshu2406/Algo.Py/issues/9
+"""
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Dict
+from typing import List
+from typing import Optional
+
+import pandas as pd
+
+from strategy.strategy_builder import StrategyBaseClass
+
+
+@dataclass
+class ValidationReport:
+    """Result of running StrategyValidator.validate()."""
+
+    passed: bool
+    schema_issues: List[str] = field(default_factory=list)
+    lookahead_issues: List[str] = field(default_factory=list)
+
+    @property
+    def issues(self) -> List[str]:
+        return self.schema_issues + self.lookahead_issues
+
+    def __str__(self) -> str:
+        if self.passed:
+            return "ValidationReport: PASSED"
+        lines = ["ValidationReport: FAILED"]
+        lines += [f"  [schema] {msg}" for msg in self.schema_issues]
+        lines += [f"  [lookahead] {msg}" for msg in self.lookahead_issues]
+        return "\n".join(lines)
+
+
+class StrategyValidator:
+    """Validates a StrategyBaseClass instance's output schema and checks for
+    look-ahead bias (data leaking from the future into past signals)."""
+
+    def validate_output_schema(
+        self,
+        entries: pd.DataFrame,
+        exits: pd.DataFrame,
+        close_data: pd.DataFrame,
+        open_data: pd.DataFrame,
+    ) -> List[str]:
+        """Structural checks on a strategy's raw output. Returns a list of
+        human-readable issue descriptions; empty list means all checks passed."""
+        issues: List[str] = []
+
+        frames = {
+            "entries": entries,
+            "exits": exits,
+            "close_data": close_data,
+            "open_data": open_data,
+        }
+        for name, df in frames.items():
+            if not isinstance(df, pd.DataFrame):
+                issues.append(f"'{name}' is not a pandas DataFrame (got {type(df).__name__}).")
+        if issues:
+            # Can't safely compare shapes/indexes if a frame isn't even a DataFrame.
+            return issues
+
+        reference_index = close_data.index
+        reference_columns = set(close_data.columns)
+        for name, df in frames.items():
+            if not df.index.equals(reference_index):
+                issues.append(f"'{name}' index does not match 'close_data' index.")
+            if set(df.columns) != reference_columns:
+                issues.append(f"'{name}' columns {set(df.columns)} do not match 'close_data' columns {reference_columns}.")
+
+        if not reference_index.is_monotonic_increasing:
+            issues.append("close_data index is not sorted in chronological (ascending) order.")
+
+        for name in ("entries", "exits"):
+            df = frames[name]
+            if df.isna().any().any():
+                issues.append(f"'{name}' contains NaN values (should be filled with False).")
+            elif df.dtypes.apply(lambda dt: dt != bool).any():
+                issues.append(f"'{name}' contains non-boolean columns.")
+
+        if entries.index.equals(exits.index) and set(entries.columns) == set(exits.columns):
+            conflicting = entries & exits
+            if conflicting.to_numpy().any():
+                bad_cells = conflicting.stack()
+                bad_cells = bad_cells[bad_cells].index.tolist()
+                issues.append(
+                    f"entries and exits are both True on the same bar for {len(bad_cells)} "
+                    f"(timestamp, symbol) cell(s), e.g. {bad_cells[:3]}."
+                )
+
+        return issues
+
+    def detect_lookahead_bias(
+        self,
+        strategy: StrategyBaseClass,
+        ohlcv_data: Dict[str, pd.DataFrame],
+        checkpoints: Optional[List[int]] = None,
+        timestamp_column: str = "timestamp",
+    ) -> List[str]:
+        """Runs `strategy` on the full history, then on truncated prefixes of
+        it, and checks that signals over the overlapping period are identical.
+
+        :param strategy: an instance of a StrategyBaseClass subclass
+        :param ohlcv_data: dict of {symbol: OHLCV DataFrame}, as passed to strategy.run()
+        :param checkpoints: bar indices at which to truncate the data and re-run;
+            defaults to the 50%, 75% and 90% marks of the shortest symbol's history
+        :param timestamp_column: name of the timestamp column, if present as a
+            column rather than already set as the index
+        :return: list of human-readable issue descriptions; empty means no leak detected
+        """
+        issues: List[str] = []
+
+        full_entries, full_exits, full_close, _ = strategy.run(ohlcv_data)
+
+        min_length = min(len(df) for df in ohlcv_data.values())
+        if checkpoints is None:
+            checkpoints = sorted(
+                {max(2, int(min_length * frac)) for frac in (0.5, 0.75, 0.9)}
+            )
+
+        for cutoff in checkpoints:
+            if cutoff >= min_length:
+                continue
+
+            truncated_data = {
+                symbol: df.iloc[:cutoff].copy() for symbol, df in ohlcv_data.items()
+            }
+            trunc_entries, trunc_exits, trunc_close, _ = strategy.run(truncated_data)
+
+            common_index = full_entries.index.intersection(trunc_entries.index)
+            common_columns = [c for c in full_entries.columns if c in trunc_entries.columns]
+            if len(common_index) == 0 or len(common_columns) == 0:
+                issues.append(
+                    f"Truncated run at cutoff={cutoff} produced no overlapping "
+                    f"index/columns with the full run — cannot compare."
+                )
+                continue
+
+            full_slice = full_entries.loc[common_index, common_columns]
+            trunc_slice = trunc_entries.loc[common_index, common_columns]
+            mismatch = full_slice != trunc_slice
+            if mismatch.to_numpy().any():
+                bad_cells = mismatch.stack()
+                bad_cells = bad_cells[bad_cells].index.tolist()
+                issues.append(
+                    f"entries differ between full-history and truncated (cutoff={cutoff}) "
+                    f"runs at {len(bad_cells)} cell(s), e.g. {bad_cells[:3]} — "
+                    f"likely look-ahead bias (signal depends on future data)."
+                )
+
+            full_exit_slice = full_exits.loc[common_index, common_columns]
+            trunc_exit_slice = trunc_exits.loc[common_index, common_columns]
+            exit_mismatch = full_exit_slice != trunc_exit_slice
+            if exit_mismatch.to_numpy().any():
+                bad_cells = exit_mismatch.stack()
+                bad_cells = bad_cells[bad_cells].index.tolist()
+                issues.append(
+                    f"exits differ between full-history and truncated (cutoff={cutoff}) "
+                    f"runs at {len(bad_cells)} cell(s), e.g. {bad_cells[:3]} — "
+                    f"likely look-ahead bias (signal depends on future data)."
+                )
+
+        return issues
+
+    def validate(
+        self,
+        strategy: StrategyBaseClass,
+        ohlcv_data: Dict[str, pd.DataFrame],
+        checkpoints: Optional[List[int]] = None,
+    ) -> ValidationReport:
+        """Runs both the output-schema and look-ahead-bias checks and returns
+        a combined ValidationReport."""
+        entries, exits, close_data, open_data = strategy.run(ohlcv_data)
+        schema_issues = self.validate_output_schema(entries, exits, close_data, open_data)
+        lookahead_issues = self.detect_lookahead_bias(strategy, ohlcv_data, checkpoints=checkpoints)
+        return ValidationReport(
+            passed=not (schema_issues or lookahead_issues),
+            schema_issues=schema_issues,
+            lookahead_issues=lookahead_issues,
+        )

--- a/tests/test_strategy_validator.py
+++ b/tests/test_strategy_validator.py
@@ -1,0 +1,162 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from strategy.strategy_builder import StrategyBaseClass
+from strategy.strategy_validator import StrategyValidator
+
+
+def _make_ohlcv_data(n_bars: int = 60, symbols=("AAA", "BBB"), seed: int = 7):
+    """Builds a small synthetic multi-symbol OHLCV dataset in the shape
+    strategy.run() expects: Dict[symbol, DataFrame(index=timestamp,
+    columns=[open, high, low, close, volume])]."""
+    rng = np.random.default_rng(seed)
+    index = pd.date_range("2024-01-01", periods=n_bars, freq="D")
+    data = {}
+    for i, symbol in enumerate(symbols):
+        close = 100 + i * 10 + np.cumsum(rng.normal(loc=0.1, scale=1.0, size=n_bars))
+        open_ = close + rng.normal(scale=0.2, size=n_bars)
+        high = np.maximum(open_, close) + rng.uniform(0, 0.5, size=n_bars)
+        low = np.minimum(open_, close) - rng.uniform(0, 0.5, size=n_bars)
+        volume = rng.integers(1_000, 10_000, size=n_bars).astype(float)
+        data[symbol] = pd.DataFrame(
+            {"open": open_, "high": high, "low": low, "close": close, "volume": volume},
+            index=index,
+        )
+    return data
+
+
+class CleanEmaStrategy(StrategyBaseClass):
+    """A well-behaved EMA-crossover strategy: every signal at time T only
+    uses close prices up to and including T (via ewm + shift(1)), so it
+    should pass both the schema and look-ahead checks."""
+
+    def __init__(self, fast: int = 5, slow: int = 15):
+        super().__init__(name="Clean EMA Strategy")
+        self.fast = fast
+        self.slow = slow
+
+    def run(self, ohlcv_data):
+        close_data = pd.DataFrame({s: df["close"] for s, df in ohlcv_data.items()})
+        open_data = pd.DataFrame({s: df["open"] for s, df in ohlcv_data.items()})
+
+        fast_ema = close_data.ewm(span=self.fast, adjust=False).mean()
+        slow_ema = close_data.ewm(span=self.slow, adjust=False).mean()
+
+        entries = (fast_ema > slow_ema) & (fast_ema.shift(1) <= slow_ema.shift(1))
+        exits = (fast_ema < slow_ema) & (fast_ema.shift(1) >= slow_ema.shift(1))
+
+        entries = entries.fillna(False).astype(bool)
+        exits = exits.fillna(False).astype(bool)
+
+        return entries, exits, close_data, open_data
+
+
+class LeakyStrategy(StrategyBaseClass):
+    """A deliberately broken strategy that peeks at tomorrow's close price
+    (shift(-1)) to decide today's entry — a classic look-ahead bias bug.
+    Used to prove StrategyValidator actually catches this."""
+
+    def __init__(self):
+        super().__init__(name="Leaky Strategy")
+
+    def run(self, ohlcv_data):
+        close_data = pd.DataFrame({s: df["close"] for s, df in ohlcv_data.items()})
+        open_data = pd.DataFrame({s: df["open"] for s, df in ohlcv_data.items()})
+
+        future_close = close_data.shift(-1)  # <-- the bug: tomorrow's price
+        entries = (future_close > close_data).fillna(False)
+        exits = (future_close < close_data).fillna(False)
+
+        return entries.astype(bool), exits.astype(bool), close_data, open_data
+
+
+class BadSchemaStrategy(StrategyBaseClass):
+    """A strategy whose output violates the schema contract: entries and
+    exits are both True on the same bar for the same symbol."""
+
+    def __init__(self):
+        super().__init__(name="Bad Schema Strategy")
+
+    def run(self, ohlcv_data):
+        close_data = pd.DataFrame({s: df["close"] for s, df in ohlcv_data.items()})
+        open_data = pd.DataFrame({s: df["open"] for s, df in ohlcv_data.items()})
+
+        entries = pd.DataFrame(True, index=close_data.index, columns=close_data.columns)
+        exits = pd.DataFrame(True, index=close_data.index, columns=close_data.columns)
+
+        return entries, exits, close_data, open_data
+
+
+class TestValidateOutputSchema:
+    def test_clean_strategy_passes_schema(self):
+        ohlcv_data = _make_ohlcv_data()
+        strategy = CleanEmaStrategy()
+        entries, exits, close_data, open_data = strategy.run(ohlcv_data)
+
+        issues = StrategyValidator().validate_output_schema(entries, exits, close_data, open_data)
+        assert issues == []
+
+    def test_conflicting_entry_exit_is_flagged(self):
+        ohlcv_data = _make_ohlcv_data()
+        strategy = BadSchemaStrategy()
+        entries, exits, close_data, open_data = strategy.run(ohlcv_data)
+
+        issues = StrategyValidator().validate_output_schema(entries, exits, close_data, open_data)
+        assert any("both True on the same bar" in issue for issue in issues)
+
+    def test_mismatched_index_is_flagged(self):
+        ohlcv_data = _make_ohlcv_data()
+        strategy = CleanEmaStrategy()
+        entries, exits, close_data, open_data = strategy.run(ohlcv_data)
+
+        truncated_entries = entries.iloc[:-1]  # drop the last row -> index mismatch
+
+        issues = StrategyValidator().validate_output_schema(
+            truncated_entries, exits, close_data, open_data
+        )
+        assert any("index does not match" in issue for issue in issues)
+
+
+class TestDetectLookaheadBias:
+    def test_clean_strategy_has_no_lookahead_bias(self):
+        ohlcv_data = _make_ohlcv_data()
+        strategy = CleanEmaStrategy()
+
+        issues = StrategyValidator().detect_lookahead_bias(strategy, ohlcv_data)
+        assert issues == []
+
+    def test_leaky_strategy_is_caught(self):
+        ohlcv_data = _make_ohlcv_data()
+        strategy = LeakyStrategy()
+
+        issues = StrategyValidator().detect_lookahead_bias(strategy, ohlcv_data)
+        assert len(issues) > 0
+        assert any("look-ahead bias" in issue for issue in issues)
+
+
+class TestValidateEndToEnd:
+    def test_clean_strategy_report_passes(self):
+        ohlcv_data = _make_ohlcv_data()
+        report = StrategyValidator().validate(CleanEmaStrategy(), ohlcv_data)
+        assert report.passed is True
+        assert report.issues == []
+
+    def test_leaky_strategy_report_fails(self):
+        ohlcv_data = _make_ohlcv_data()
+        report = StrategyValidator().validate(LeakyStrategy(), ohlcv_data)
+        assert report.passed is False
+        assert len(report.lookahead_issues) > 0
+
+    def test_bad_schema_strategy_report_fails(self):
+        ohlcv_data = _make_ohlcv_data()
+        report = StrategyValidator().validate(BadSchemaStrategy(), ohlcv_data)
+        assert report.passed is False
+        assert len(report.schema_issues) > 0
+
+    def test_report_str_is_readable(self):
+        ohlcv_data = _make_ohlcv_data()
+        report = StrategyValidator().validate(BadSchemaStrategy(), ohlcv_data)
+        text = str(report)
+        assert "FAILED" in text
+        assert "[schema]" in text


### PR DESCRIPTION
## Summary
Implements the core, most concrete part of #9 — an abstract-style verification harness that checks a strategy for structural validity and, most importantly, **look-ahead bias** (data leaking from the future into past signals).

- `strategy/strategy_validator.py` — new `StrategyValidator` class:
  - `validate_output_schema()`: checks `entries`/`exits`/`close_data`/`open_data` share the same index/columns, `entries`/`exits` are boolean with no NaNs, index is chronologically sorted, and no bar has both an entry and exit signal for the same symbol.
  - `detect_lookahead_bias()`: runs the strategy once on the full OHLCV history, then again on truncated prefixes (e.g. 50%/75%/90% of the data). A correct strategy's signal at time T can only depend on data up to T, so the truncated run's signals over the overlapping period must exactly match the full run's. Any mismatch proves the strategy read future data.
  - `validate()`: convenience method running both checks, returning a `ValidationReport` (`passed: bool`, plus readable issue descriptions).
- `tests/test_strategy_validator.py` (9 tests, all passing) using:
  - a clean EMA-crossover strategy → validator reports `PASSED`
  - a deliberately broken strategy that peeks at `close.shift(-1)` (tomorrow's price) → caught by `detect_lookahead_bias`
  - a strategy with conflicting entry+exit signals on the same bar → caught by `validate_output_schema`
  - sanity-checked against the repo's real `strategy.public.EmaStrat.EMAStrategy` — passes cleanly, no false positives
- Short usage section added to `docs/strategy_development.md`.

### Scope note
#9 mentions three things: (1) no data leaks into the future, (2) trades are structurally valid, (3) an indicator registry similar to `strategy_registry.py`. This PR covers (1) and (2) — they share the same validator and are directly testable/provable. (3) is a materially different, larger feature (a whole new registry + discovery mechanism for indicators) and felt out of scope for one PR — happy to take that on separately if you'd like it split out as its own issue/PR.

## Test plan
- [x] `python -m pytest tests/test_strategy_validator.py -v` — 9/9 passing
- [x] Ran `StrategyValidator` against the real `EMAStrategy` in `strategy/public/EmaStrat.py` with synthetic OHLCV data — reports `PASSED`, confirming no false positives on production code
- [x] Confirmed issue #9 is still open with no other PR addressing it